### PR TITLE
Booleanfield configuration

### DIFF
--- a/sentry_pushover/plugin.py
+++ b/sentry_pushover/plugin.py
@@ -45,7 +45,8 @@ class PushoverSettingsForm(forms.Form):
                                  help_text="Don't send notifications for events below this level.")
 
     priority = \
-        forms.BooleanField(help_text='High-priority notifications, also bypasses quiet hours.')
+        forms.BooleanField(required=False,
+                           help_text='High-priority notifications, also bypasses quiet hours.')
 
 
 class PushoverNotifications(Plugin):


### PR DESCRIPTION
The booleanfield in the plugin form needs to have required=False set or else it will error when the form item is unchecked.

See https://docs.djangoproject.com/en/dev/ref/forms/fields/#booleanfield for details.
